### PR TITLE
[1.1.1] Add mint field to treasury accounts

### DIFF
--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zoints/treasury",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "The JavaScript library for the treasury",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/js/src/accounts.ts
+++ b/js/src/accounts.ts
@@ -9,16 +9,23 @@ export enum SimpleTreasuryMode {
 }
 
 export class SimpleTreasury {
+    public mint: PublicKey;
     public mode: SimpleTreasuryMode;
     public authority: PublicKey;
 
-    constructor(params: { mode: SimpleTreasuryMode; authority: PublicKey }) {
+    constructor(params: {
+        mint: PublicKey;
+        mode: SimpleTreasuryMode;
+        authority: PublicKey;
+    }) {
+        this.mint = params.mint;
         this.mode = params.mode;
         this.authority = params.authority;
     }
 }
 
 export class VestedTreasury {
+    public mint: PublicKey;
     public authority: PublicKey;
     public initialAmount: BN;
     public start: Date;
@@ -27,6 +34,7 @@ export class VestedTreasury {
     public withdrawn: BN;
 
     constructor(params: {
+        mint: PublicKey;
         authority: PublicKey;
         initialAmount: BN;
         start: BN;
@@ -34,6 +42,7 @@ export class VestedTreasury {
         vestmentPercentage: number;
         withdrawn: BN;
     }) {
+        this.mint = params.mint;
         this.authority = params.authority;
         this.initialAmount = params.initialAmount;
         this.start = new Date(params.start.toNumber() * 1000);
@@ -68,7 +77,7 @@ export const ACCOUNT_SCHEMA: borsh.Schema = new Map<any, any>([
         {
             kind: 'struct',
             fields: [
-                ['token', 'PublicKey'],
+                ['mint', 'PublicKey'],
                 ['mode', 'SimpleTreasuryMode'],
                 ['authority', 'PublicKey']
             ]
@@ -79,7 +88,7 @@ export const ACCOUNT_SCHEMA: borsh.Schema = new Map<any, any>([
         {
             kind: 'struct',
             fields: [
-                ['token', 'PublicKey'],
+                ['mint', 'PublicKey'],
                 ['authority', 'PublicKey'],
                 ['initialAmount', 'u64'],
                 ['start', 'u64'],


### PR DESCRIPTION
The mint was present in the borsh decoding but was not available via the struct.